### PR TITLE
Nested HTML is moved incorrectly

### DIFF
--- a/bootstrap-tabcollapse.js
+++ b/bootstrap-tabcollapse.js
@@ -53,8 +53,7 @@
         $panelBodies.each(function(){
             var $panelBody = $(this),
                 $tabPane = $panelBody.data('bs.tabcollapse.tabpane');
-            $tabPane.append($panelBody.html());
-            $panelBody.find('*').detach();
+            $tabPane.append($panelBody.children('*').detach());
         });
         this.$accordion.html('');
 
@@ -103,11 +102,9 @@
 
         var $tabPane = $(tabSelector),
             groupId = $tabPane.attr('id') + '-collapse',
-            $panel = $(this.options.accordionTemplate($heading.html(), groupId, parentId, active)),
-            $panelBody = $panel.find('.panel-body');
-        $panelBody.append($tabPane.html());
-        $tabPane.find('*').detach();
-        $panelBody.data('bs.tabcollapse.tabpane', $tabPane);
+            $panel = $(this.options.accordionTemplate($heading.html(), groupId, parentId, active));
+        $panel.find('.panel-body').append($tabPane.children('*').detach())
+            .data('bs.tabcollapse.tabpane', $tabPane);
 
         return $panel;
     };


### PR DESCRIPTION
If the tabs component the script is applied to contains nested HTML (for instance a &lt;ul&gt; containing &lt;li&gt; nodes) the structure will not be preserved when switching between components. The DOM items will be added after each other which results in invalid HTML (as the list items will be outside of the list).

The issue can be observed in the following fiddle: http://jsfiddle.net/yVz7v/4/
Solved with the fix applied in my fork: http://jsfiddle.net/yVz7v/3/
