### PR TITLE
Include text nodes in tab/collapse content

### DIFF
--- a/bootstrap-tabcollapse.js
+++ b/bootstrap-tabcollapse.js
@@ -88,7 +88,7 @@
         $panelBodies.each(function(){
             var $panelBody = $(this),
                 $tabPane = $panelBody.data('bs.tabcollapse.tabpane');
-            $tabPane.append($panelBody.children('*').detach());
+            $tabPane.append($panelBody.contents().detach());
         });
         this.$accordion.html('');
 
@@ -191,7 +191,7 @@
             groupId = $tabPane.attr('id') + '-collapse',
             $panel = $(this.options.accordionTemplate($heading, groupId, parentId, active));
         $panel.find('.panel-heading > .panel-title').append(this._tabHeadingToPanelHeading($heading, groupId, parentId, active));
-        $panel.find('.panel-body').append($tabPane.children('*').detach())
+        $panel.find('.panel-body').append($tabPane.contents().detach())
             .data('bs.tabcollapse.tabpane', $tabPane);
 
         return $panel;


### PR DESCRIPTION
If your tabs contain text nodes as immediate children of `.tab-pane` element, then the text nodes will remain in the `.tab-pane` element and not be copied to the `.panel-body` element. This PR fixes this issue.