### PR TITLE
Add option to set a breakpoint to determine when the tabs switch to an accordion

### DIFF
--- a/bootstrap-tabcollapse.js
+++ b/bootstrap-tabcollapse.js
@@ -42,10 +42,20 @@
     };
 
     TabCollapse.prototype.checkState = function(){
-        if (this.$tabs.is(':visible') && this._accordionVisible){
+        var openTabs = this.$tabs.is(':visible');
+        var openAccordion = this.$accordion.is(':visible');
+
+        if (this.options.breakpoint && this.options.breakpoint > 0) {
+            var windowWidth = window.innerWidth;
+
+            openTabs = windowWidth >= this.options.breakpoint;
+            openAccordion = windowWidth < this.options.breakpoint;
+        }
+
+        if (openTabs && this._accordionVisible){
             this.showTabs();
             this._accordionVisible = false;
-        } else if (this.$accordion.is(':visible') && !this._accordionVisible){
+        } else if (openAccordion && !this._accordionVisible){
             this.showAccordion();
             this._accordionVisible = true;
         }


### PR DESCRIPTION
Added a breakpoint option to determine when tabs switch to an accordion instead of using CSS classes. The plugin was breaking for me (on the `is(':visible')` check) when the element was inside of a flexbox element and this was my solution. 

Example usage:

```
$('#myTab').tabCollapse({
  breakpoint: 720
});
```

This would cause the tabs to be displayed when the screen is greater than or equal to 720px and the accordion when the screen is less than 720px.