### PR TITLE
Initialize tabcollapse even when it is hidden

### DIFF
--- a/bootstrap-tabcollapse.js
+++ b/bootstrap-tabcollapse.js
@@ -42,10 +42,12 @@
     };
 
     TabCollapse.prototype.checkState = function(){
-        if (this.$tabs.is(':visible') && this._accordionVisible){
+        var hiddenCssClass = this.options.tabsClass;
+
+        if (!this.$tabs.hasClass(hiddenCssClass) && this._accordionVisible){
             this.showTabs();
             this._accordionVisible = false;
-        } else if (this.$accordion.is(':visible') && !this._accordionVisible){
+        } else if (!this.$accordion.hasClass(hiddenCssClass) && !this._accordionVisible){
             this.showAccordion();
             this._accordionVisible = true;
         }

--- a/bootstrap-tabcollapse.js
+++ b/bootstrap-tabcollapse.js
@@ -36,7 +36,7 @@
                     '       <div class="panel-body js-tabcollapse-panel-body">' +
                     '       </div>' +
                     '   </div>' +
-                    '</div>'
+                    '</div>';
 
         }
     };
@@ -83,7 +83,7 @@
         });
 
         if (!$('li').hasClass('active')) {
-            $('li').first().addClass('active')
+            $('li').first().addClass('active');
         }
 
         var $panelBodies = this.$accordion.find('.js-tabcollapse-panel-body');

--- a/bootstrap-tabcollapse.js
+++ b/bootstrap-tabcollapse.js
@@ -1,4 +1,4 @@
-!function ($) {
+(function ($) {
 
     "use strict";
 
@@ -235,5 +235,4 @@
 
     $.fn.tabCollapse.Constructor = TabCollapse;
 
-
-}(window.jQuery);
+})(window.jQuery);

--- a/bootstrap-tabcollapse.js
+++ b/bootstrap-tabcollapse.js
@@ -9,7 +9,6 @@
         this.options   = options;
         this.$tabs  = $(el);
 
-        this._accordionVisible = false; //content is attached to tabs at first
         this._initAccordion();
         this._checkStateOnResize();
 
@@ -41,16 +40,11 @@
         }
     };
 
-    TabCollapse.prototype.checkState = function(){
-        var hiddenCssClass = this.options.tabsClass;
-
-        if (!this.$tabs.hasClass(hiddenCssClass) && this._accordionVisible){
-            this.showTabs();
-            this._accordionVisible = false;
-        } else if (!this.$accordion.hasClass(hiddenCssClass) && !this._accordionVisible){
-            this.showAccordion();
-            this._accordionVisible = true;
-        }
+    TabCollapse.prototype.checkState = function() {
+      if(this.$accordion.css('display') === 'block')
+        this.showAccordion();
+      else if (this.$tabs.css('display') === 'block')
+        this.showTabs();
     };
 
     TabCollapse.prototype.showTabs = function(){

--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
     "name": "bootstrap-tabcollapse",
     "main": "bootstrap-tabcollapse.js",
-    "version": "0.2.7",
+    "version": "0.3.0",
     "homepage": "https://github.com/flatlogic/bootstrap-tabcollapse",
     "authors": [
         "okendoken (http://flatlogic.com)"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "bootstrap-tabcollapse",
+  "version": "1.0.0",
+  "description": "Bootstrap Tab Collapse ======================",
+  "main": "bootstrap-tabcollapse.js",
+  "directories": {
+    "example": "example"
+  },
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GregOnNet/bootstrap-tabcollapse.git"
+  },
+  "keywords": [],
+  "author": "Gregor Woiwode <gregor.woiwode@gmail.com>",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/GregOnNet/bootstrap-tabcollapse/issues"
+  },
+  "homepage": "https://github.com/GregOnNet/bootstrap-tabcollapse#readme"
+}

--- a/package.json
+++ b/package.json
@@ -1,20 +1,21 @@
 {
   "name": "bootstrap-tabcollapse",
-  "version": "1.0.0",
+  "version": "0.3.0",
   "description": "Bootstrap Tab Collapse ======================",
   "main": "bootstrap-tabcollapse.js",
   "directories": {
     "example": "example"
   },
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/GregOnNet/bootstrap-tabcollapse.git"
   },
-  "keywords": [],
-  "author": "Gregor Woiwode <gregor.woiwode@gmail.com>",
+  "keywords": ["bootstrap", "tabs", "collapse", "tabcollapse", "responsive"],
+  "author":{
+    "name": "okendoken",
+    "url": "http://flatlogic.com"
+  },
+  "contributors": ["Gregor Woiwode <gregor.woiwode@gmail.com>"],
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/GregOnNet/bootstrap-tabcollapse/issues"

--- a/readme.md
+++ b/readme.md
@@ -19,61 +19,70 @@ Use
 
 Lets say you have your tabs component right from bootstrap's site:
 
-    <ul id="myTab" class="nav nav-tabs">
-      <li class="active"><a href="#home" data-toggle="tab">Home</a></li>
-      <li><a href="#profile" data-toggle="tab">Profile</a></li>
-      ...
-    </ul>
-    <div id="myTabContent" class="tab-content">
-        <div class="tab-pane fade in active" id="home">
-            <p>Raw denim you probably haven't...</p>
-        </div>
-        <div class="tab-pane fade" id="profile">
-            <p>Food truck fixie locavore, accus...</p>
-        </div>
-        ...
+```html
+<ul id="myTab" class="nav nav-tabs">
+  <li class="active"><a href="#home" data-toggle="tab">Home</a></li>
+  <li><a href="#profile" data-toggle="tab">Profile</a></li>
+  ...
+</ul>
+<div id="myTabContent" class="tab-content">
+    <div class="tab-pane fade in active" id="home">
+        <p>Raw denim you probably haven't...</p>
     </div>
-
+    <div class="tab-pane fade" id="profile">
+        <p>Food truck fixie locavore, accus...</p>
+    </div>
+    ...
+</div>
+```
 To activate tab collapse just include **bootstrap-tabcollapse.js** somewhere in your file and call:
 
     $('#myTab').tabCollapse();
 
 If you want to specify the class that is given to accordion and tabs components you can do so by passing options to `tabCollapse`:
 
-    $('#myTab').tabCollapse({
-        tabsClass: 'hidden-sm',
-        accordionClass: 'visible-sm'
-    });
+```js
+$('#myTab').tabCollapse({
+    tabsClass: 'hidden-sm',
+    accordionClass: 'visible-sm'
+});
+```
 
 The default class is `hidden-xs`. So it means that tabs component will be switched to accordion for 767px and below. You can define your own classes and use them.
 You can also use multiple Bootstrap classes in order to, for example, show accordion for mobile + tablets and tabs for desktop+:
 
-    $('#myTab').tabCollapse({
-        tabsClass: 'hidden-sm hidden-xs',
-        accordionClass: 'visible-sm visible-xs'
-    });
+```js
+$('#myTab').tabCollapse({
+    tabsClass: 'hidden-sm hidden-xs',
+    accordionClass: 'visible-sm visible-xs'
+});
+```
 
 Events
 ------------
 
 There are four events tabcollapse triggers (for **entire** component, not for single tabs or accordion groups!):
--   **show-tabs.bs.tabcollapse** - triggered before tabs component is shown
--   **shown-tabs.bs.tabcollapse** - triggered after tabs component is shown
--   **show-accordion.bs.tabcollapse** - triggered before accordion component is shown
--   **shown-accordion.bs.tabcollapse** - triggered after accordion component is shown
+-   `show-tabs.bs.tabcollapse` - triggered before tabs component is shown
+-   `shown-tabs.bs.tabcollapse` - triggered after tabs component is shown
+-   `show-accordion.bs.tabcollapse` - triggered before accordion component is shown
+-   `shown-accordion.bs.tabcollapse` - triggered after accordion component is shown
 
 To attach event handler just call:
 
-    $('#myTab').on('shown-accordion.bs.tabcollapse', function(){
-        alert('accordion is shown now!');
-    });
+```js
+$('#myTab').on('shown-accordion.bs.tabcollapse', function(){
+    alert('accordion is shown now!');
+});
+```
 
 Attach an event handler when **either** tab or collapse is opened:
 ------------
 
-    $(document).on("shown.bs.collapse shown.bs.tab", ".panel-collapse, a[data-toggle='tab']", function (e) {
-        alert('either tab or collapse opened - check arguments to distinguish ' + e);
-    });
+```js
+$(document).on("shown.bs.collapse shown.bs.tab", ".panel-collapse, a[data-toggle='tab']", function (e) {
+    alert('either tab or collapse opened - check arguments to distinguish ' + e);
+});
+```
 
 Contributors
 ------------


### PR DESCRIPTION
Hey,

thanks for provding `bootstrap-tabcollapse`. It really helps me out creating the mobile <-> desktop switch on my own.

In my project I initialize `bootstrap-tabcollapse` in a container having the css-property `display: none` set.
Till now you check for is(':visible') to decide whether to show Tabs or Accordion I updated the condition to look for the configured hidden classes (default: 'hidden-xs').

Hope this helps you, too.

Kind
Greg
