### PR TITLE
Fixing panel heading properties for expand

### DIFF
--- a/bootstrap-tabcollapse.js
+++ b/bootstrap-tabcollapse.js
@@ -209,7 +209,9 @@
         var $tabPane = $(tabSelector),
             groupId = $tabPane.attr('id') + '-collapse',
             $panel = $(this.options.accordionTemplate($heading, groupId, parentId, active));
-        $panel.find('.panel-heading > .panel-title').append(this._tabHeadingToPanelHeading($heading, groupId, parentId, active));
+        var panelHeading = $panel.find('.panel-heading');
+        this._tabHeadingToPanelHeading(panelHeading, groupId, parentId, active);
+        $panel.find('.panel-heading > .panel-title').append($heading);
         $panel.find('.panel-body').append($tabPane.contents().detach())
             .data('bs.tabcollapse.tabpane', $tabPane);
 


### PR DESCRIPTION
Fixing panel heading properties so that click on the panel heading and not only on the title causes it expand or collapse