### PR TITLE
Fix for targeting all li's on page

### DIFF
--- a/bootstrap-tabcollapse.js
+++ b/bootstrap-tabcollapse.js
@@ -80,8 +80,8 @@
             $parentLi.append($panelHeading);
         });
 
-        if (!$('li').hasClass('active')) {
-            $('li').first().addClass('active')
+        if (!$panelHeadings.parent().hasClass('active')) {
+            $panelHeadings.parent().first().addClass('active')
         }
 
         var $panelBodies = this.$accordion.find('.js-tabcollapse-panel-body');


### PR DESCRIPTION
Fix for issue where all first li's across the page get an active class when running showTabs