### PR TITLE
Add fix for tab selection on resize

### DIFF
--- a/bootstrap-tabcollapse.js
+++ b/bootstrap-tabcollapse.js
@@ -82,6 +82,10 @@
 
         if (!$('li').hasClass('active')) {
             $('li').first().addClass('active')
+        } else {
+            var targetSelector = this.$tabs.find("li.active a").attr("href");
+            this.$tabs.parent().find(".tab-pane").removeClass("active in");
+            $(targetSelector).addClass("active in");
         }
 
         var $panelBodies = this.$accordion.find('.js-tabcollapse-panel-body');


### PR DESCRIPTION
Update to #17, caption is set correctly on resizing from accordion to tab, but content is ignored. Probably no perfect js, but a working option.